### PR TITLE
Reflect.set() & Reflect.construct() fixes

### DIFF
--- a/src/org/mozilla/javascript/NativeReflect.java
+++ b/src/org/mozilla/javascript/NativeReflect.java
@@ -181,7 +181,7 @@ final class NativeReflect extends ScriptableObject {
             if (result != null) {
                 result.setPrototype((Scriptable) newTargetPrototype);
 
-                Object val = ctorBaseFunction.call(cx, scope, result, args);
+                Object val = ctorBaseFunction.call(cx, scope, result, callArgs);
                 if (val instanceof Scriptable) {
                     return (Scriptable) val;
                 }

--- a/src/org/mozilla/javascript/NativeReflect.java
+++ b/src/org/mozilla/javascript/NativeReflect.java
@@ -325,21 +325,35 @@ final class NativeReflect extends ScriptableObject {
 
     private static Object set(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
-
-        if (args.length > 1) {
-            if (ScriptRuntime.isSymbol(args[1])) {
-                target.put((Symbol) args[1], target, args[2]);
-                return true;
-            }
-            if (args[1] instanceof Double) {
-                target.put(ScriptRuntime.toIndex(args[1]), target, args[2]);
-                return true;
-            }
-
-            target.put(ScriptRuntime.toString(args[1]), target, args[2]);
+        if (args.length < 2) {
             return true;
         }
-        return false;
+
+        ScriptableObject receiver = args.length > 3 ? ScriptableObject.ensureScriptableObject(args[3]) : target;
+        if (receiver != target) {
+            ScriptableObject descriptor = target.getOwnPropertyDescriptor(cx, args[1]);
+            if (descriptor != null) {
+                Object setter = descriptor.get("set");
+                if (setter != null && setter != NOT_FOUND) {
+                    ((Function) setter).call(cx, scope, receiver, new Object[] {args[2]});
+                    return true;
+                }
+
+                if (descriptor.get("configurable") == Boolean.FALSE) {
+                    return false;
+                }
+            }
+        }
+
+        if (ScriptRuntime.isSymbol(args[1])) {
+            receiver.put((Symbol) args[1], receiver, args[2]);
+        } else if (args[1] instanceof Double) {
+            receiver.put(ScriptRuntime.toIndex(args[1]), receiver, args[2]);
+        } else {
+            receiver.put(ScriptRuntime.toString(args[1]), receiver, args[2]);
+        }
+
+        return true;
     }
 
     private static Object setPrototypeOf(


### PR DESCRIPTION
### This PR does the following:

#### 1. Fix a bug in `Reflect.construct()` where the wrong set of arguments is given to the constructor call when `newTarget` is set.

These tests showcase the buggy behavior of the current `Reflect.construct()` implementation.
```html
<!DOCTYPE html>
<html>
<head>
<script>
function foo(a, b) {
  console.log("foo", this.__proto__.constructor);
  for (let i = 0; i < arguments.length; i++) {
    console.log(arguments[i]);
  }
}

function bar(a, b, c) {
  console.log("bar", this.__proto__.constructor);
  for (let i = 0; i < arguments.length; i++) {
    console.log(arguments[i]);
  }
}

// result same as expected: "foo function foo() {...} 1 2"
Reflect.construct(foo, [1, 2]);

// result same as expected: "bar function bar() {...} 3 4 5"
Reflect.construct(bar, [3, 4, 5]);

// expected: "foo function bar() {...} 6 7
// got: "foo function bar() {...} function foo() {...} [6,7,8] function bar() {...}
Reflect.construct(foo, [6, 7, 8], bar);
</script>
</head>
<body>
</body>
</html>

```
#### 2. Add [receiver](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set#receiver) argument support for `Reflect.set()`.

This is the test cases i used to test this implementation.
```html
<!DOCTYPE html>
<html>
<head>
<script>
var target = {}, receiver = {};
console.log(Reflect.set(target, "a", 2, receiver)); // true
console.log(target, receiver); // {} { a: 2 }

var target = { a: 1 }, receiver = {};
console.log(Reflect.set(target, "a", 2, receiver)); // true
console.log(target, receiver); // { a: 1 } { a: 2 }

var target = {}, receiver = {};
Object.defineProperty(target, "a", {
  value: 1,
  enumerable: true,
  configurable: false,
});
console.log(Reflect.set(target, "a", 2, receiver)); // false
console.log(target, receiver); // { a: 1 } {}

var target = {}, receiver = {};
Object.defineProperty(target, "a", {
  set: function(v) {
    this.b = v;
  },
  enumerable: true,
});
console.log(Reflect.set(target, "a", 2, receiver)); // true
console.log(target, receiver); // {} { b: 2 }

var SYM = Symbol.for("a"), target = {}, receiver = {};
target[SYM] = 1;
console.log(Reflect.set(target, SYM, 2, receiver)); // true
console.log(Object.getOwnPropertySymbols(target), Object.getOwnPropertySymbols(receiver)); // [ Symbol(a) ] [ Symbol(a) ]
console.log(target[SYM], receiver[SYM]) // 1 2

var SYM = Symbol.for("a"), target = {}, receiver = {};
Object.defineProperty(target, SYM, {
  value: 1,
  configurable: false,
})
console.log(Reflect.set(target, SYM, 2, receiver)); // false
console.log(Object.getOwnPropertySymbols(target), Object.getOwnPropertySymbols(receiver)) // [ Symbol(a) ] []

var SYM_A = Symbol.for("a"), SYM_B = Symbol.for("b");
var target = {}, receiver = {};
Object.defineProperty(target, SYM_A, {
  set: function(v) {
    this[SYM_B] = v;
  },
})
console.log(Reflect.set(target, SYM_A, 2, receiver)); // true
console.log(Object.getOwnPropertySymbols(target), Object.getOwnPropertySymbols(receiver), receiver[SYM_B]); // [ Symbol(a) ] [ Symbol(b) ] 2
</script>
</head>
<body>
</body>
</html>

```

### Remark
These are the tests we're using but it's in our format so I couldn't added it to htmlunit sorry. 