### PR TITLE
SpecialRef: fix assigning to Symbol.__proto__ returning undefined

### DIFF
--- a/src/org/mozilla/javascript/SpecialRef.java
+++ b/src/org/mozilla/javascript/SpecialRef.java
@@ -114,6 +114,10 @@ class SpecialRef extends Ref {
                             }
 
                             final String typeOfValue = ScriptRuntime.typeof(value);
+                            if (NativeSymbol.TYPE_NAME.equals(typeOfTarget)) {
+                                return value;
+                            }
+
                             if ((value != null && !"object".equals(typeOfValue))
                                     || !"object".equals(typeOfTarget)) {
                                 return Undefined.instance;


### PR DESCRIPTION
### This PR does the following
- Fix an issue where assigning to `Symbol`'s proto incorrectly returns undefined

### Reproducing
This showcases the existing problem
  ```javascript
var x = Symbol();
var y = { foo: "bar" }

// expected: { foo: "bar" }, got: undefined
console.log(x.__proto__ = y);
  ```

### Remark
I believe this is a regression from https://github.com/mozilla/rhino/commit/9a6343448a886b4fd2ba104c2d1100ac0f163896