### PR TITLE
NativeTypedArrayView: support Symbol.toStringTag

### DIFF
--- a/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/src/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -421,6 +421,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             initPrototypeMethod(getClassName(), id, SymbolKey.ITERATOR, "[Symbol.iterator]", 0);
             return;
         }
+        if (id == SymbolId_toStringTag) {
+            initPrototypeValue(
+                    SymbolId_toStringTag,
+                    SymbolKey.TO_STRING_TAG,
+                    getClassName(),
+                    DONTENUM | READONLY);
+            return;
+        }
 
         String s, fnName = null;
         int arity;
@@ -459,6 +467,9 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     protected int findPrototypeId(Symbol k) {
         if (SymbolKey.ITERATOR.equals(k)) {
             return SymbolId_iterator;
+        }
+        if (SymbolKey.TO_STRING_TAG.equals(k)) {
+            return SymbolId_toStringTag;
         }
         return 0;
     }
@@ -499,9 +510,10 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             Id_set = 4,
             Id_subarray = 5,
             Id_at = 6,
-            SymbolId_iterator = 7;
+            SymbolId_iterator = 7,
+            SymbolId_toStringTag = 8;
 
-    protected static final int MAX_PROTOTYPE_ID = SymbolId_iterator;
+    protected static final int MAX_PROTOTYPE_ID = SymbolId_toStringTag;
 
     // Constructor properties
 


### PR DESCRIPTION
### This PR does the following
- Add [Symbol.toStringTag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) support for `NativeTypedArrayView`, including `Float32Array`, `Float64Array`, `Int8Array`, `Int16Array`, `Int32Array`, `Uint8Array`, `Uint16Array`, `Uint32Array` and `Uint8ClampedArray`.

### Test cases
  ```javascript
<!DOCTYPE html>
<html>
<head>
<script>
console.log((new Float32Array(1))[Symbol.toStringTag]); // Float32Array
console.log((new Float64Array(1))[Symbol.toStringTag]); // Float64Array
console.log((new Int8Array(1))[Symbol.toStringTag]); // Int8Array
console.log((new Int16Array(1))[Symbol.toStringTag]); // Int16Array
console.log((new Int32Array(1))[Symbol.toStringTag]); // Int32Array
console.log((new Uint8Array(1))[Symbol.toStringTag]); // Uint8Array
console.log((new Uint16Array(1))[Symbol.toStringTag]); // Uint16Array
console.log((new Uint32Array(1))[Symbol.toStringTag]); // Uint32Array
console.log((new Uint8ClampedArray(1))[Symbol.toStringTag]); // Uint8ClampedArray
</script>
</head>
<body>
</body>
</html>
  ```