### PR TITLE
NativeDate: Add JST support, refactor to use java.time, fix locales argument

### DIFF
--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -1204,7 +1204,7 @@ final class NativeDate extends IdScriptableObject {
                                 + "saturday;sunday;"
                                 + "january;february;march;april;may;june;"
                                 + "july;august;september;october;november;december;"
-                                + "gmt;ut;utc;est;edt;cst;cdt;mst;mdt;pst;pdt;";
+                                + "gmt;ut;utc;est;edt;cst;cdt;mst;mdt;pst;pdt;jst;";
                 int index = 0;
                 for (int wtbOffset = 0; ; ) {
                     int wtbNext = wtb.indexOf(';', wtbOffset);
@@ -1272,6 +1272,9 @@ final class NativeDate extends IdScriptableObject {
                             break;
                         case 10 /* pdt */:
                             tzoffset = 7 * 60;
+                            break;
+                        case 11 /* jst */:
+                            tzoffset = -9 * 60;
                             break;
                         default:
                             Kit.codeBug();

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -9,7 +9,11 @@ package org.mozilla.javascript;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * This class implements the Date native object. See ECMA 15.9.
@@ -340,7 +344,7 @@ final class NativeDate extends IdScriptableObject {
             case Id_toLocaleTimeString:
             case Id_toLocaleDateString:
                 if (!Double.isNaN(t)) {
-                    return toLocale_helper(t, id);
+                    return toLocale_helper(t, id, args);
                 }
                 return js_NaN_date_str;
 
@@ -1403,7 +1407,7 @@ final class NativeDate extends IdScriptableObject {
         return obj;
     }
 
-    private static String toLocale_helper(double t, int methodId) {
+    private static String toLocale_helper(double t, int methodId, Object[] args) {
         DateTimeFormatter formatter;
         switch (methodId) {
             case Id_toLocaleString:
@@ -1417,6 +1421,29 @@ final class NativeDate extends IdScriptableObject {
                 break;
             default:
                 throw new AssertionError(); // unreachable
+        }
+
+        final List<String> languageTags = new ArrayList<>();
+        if (args.length != 0) {
+            // we use the 'locales' argument but ignore the second 'options' argument as per spec of an
+            // implementation that has no Intl.DateTimeFormat support
+            if (args[0] instanceof NativeArray) {
+                final NativeArray array = (NativeArray) args[0];
+                for (Object languageTag : array) {
+                    languageTags.add(Context.toString(languageTag));
+                }
+            } else {
+                languageTags.add(Context.toString(args[0]));
+            }
+        }
+
+        final List<Locale> availableLocales = Arrays.asList(Locale.getAvailableLocales());
+        for (String languageTag : languageTags) {
+            Locale locale = Locale.forLanguageTag(languageTag);
+            if (availableLocales.contains(locale)) {
+                formatter = formatter.withLocale(locale);
+                break;
+            }
         }
 
         return formatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE));

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -6,8 +6,9 @@
 
 package org.mozilla.javascript;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 /**
@@ -23,6 +24,9 @@ final class NativeDate extends IdScriptableObject {
     private static final Object DATE_TAG = "Date";
 
     private static final String js_NaN_date_str = "Invalid Date";
+
+    // TODO: we probably shouldn't be hard coding this to be platform dependent
+    private static final ZoneId HOST_TIME_ZONE = ZoneId.systemDefault();
 
     static void init(Scriptable scope, boolean sealed) {
         NativeDate obj = new NativeDate();
@@ -1351,10 +1355,7 @@ final class NativeDate extends IdScriptableObject {
                 t = MakeDate(day, TimeWithinDay(t));
             }
             result.append(" (");
-            Date date = new Date((long) t);
-            synchronized (timeZoneFormatter) {
-                result.append(timeZoneFormatter.format(date));
-            }
+            result.append(timeZoneFormatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE)));
             result.append(')');
         }
         return result.toString();
@@ -1403,7 +1404,7 @@ final class NativeDate extends IdScriptableObject {
     }
 
     private static String toLocale_helper(double t, int methodId) {
-        DateFormat formatter;
+        DateTimeFormatter formatter;
         switch (methodId) {
             case Id_toLocaleString:
                 formatter = localeDateTimeFormatter;
@@ -1418,9 +1419,7 @@ final class NativeDate extends IdScriptableObject {
                 throw new AssertionError(); // unreachable
         }
 
-        synchronized (formatter) {
-            return formatter.format(new Date((long) t));
-        }
+        return formatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE));
     }
 
     private static String js_toUTCString(double date) {
@@ -1920,11 +1919,10 @@ final class NativeDate extends IdScriptableObject {
     private static final int Id_toGMTString = Id_toUTCString; // Alias, see Ecma B.2.6
 
     // not thread safe
-    private static final DateFormat timeZoneFormatter = new SimpleDateFormat("zzz");
-    private static final DateFormat localeDateTimeFormatter =
-            new SimpleDateFormat("MMMM d, yyyy h:mm:ss a z");
-    private static final DateFormat localeDateFormatter = new SimpleDateFormat("MMMM d, yyyy");
-    private static final DateFormat localeTimeFormatter = new SimpleDateFormat("h:mm:ss a z");
+    private static final DateTimeFormatter timeZoneFormatter = DateTimeFormatter.ofPattern("zzz");
+    private static final DateTimeFormatter localeDateTimeFormatter = DateTimeFormatter.ofPattern("MMMM d, yyyy h:mm:ss a z");
+    private static final DateTimeFormatter localeDateFormatter = DateTimeFormatter.ofPattern("MMMM d, yyyy");
+    private static final DateTimeFormatter localeTimeFormatter = DateTimeFormatter.ofPattern("h:mm:ss a z");
 
     private double date;
 }

--- a/src/org/mozilla/javascript/NativeDate.java
+++ b/src/org/mozilla/javascript/NativeDate.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
 /**
  * This class implements the Date native object. See ECMA 15.9.
@@ -29,8 +30,7 @@ final class NativeDate extends IdScriptableObject {
 
     private static final String js_NaN_date_str = "Invalid Date";
 
-    // TODO: we probably shouldn't be hard coding this to be platform dependent
-    private static final ZoneId HOST_TIME_ZONE = ZoneId.systemDefault();
+    private static final Supplier<ZoneId> HOST_TIME_ZONE_SUPPLIER = () -> Context.getCurrentContext().getTimeZone().toZoneId();
 
     static void init(Scriptable scope, boolean sealed) {
         NativeDate obj = new NativeDate();
@@ -1359,7 +1359,7 @@ final class NativeDate extends IdScriptableObject {
                 t = MakeDate(day, TimeWithinDay(t));
             }
             result.append(" (");
-            result.append(timeZoneFormatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE)));
+            result.append(timeZoneFormatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE_SUPPLIER.get())));
             result.append(')');
         }
         return result.toString();
@@ -1446,7 +1446,7 @@ final class NativeDate extends IdScriptableObject {
             }
         }
 
-        return formatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE));
+        return formatter.format(Instant.ofEpochMilli((long) t).atZone(HOST_TIME_ZONE_SUPPLIER.get()));
     }
 
     private static String js_toUTCString(double date) {

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -221,19 +221,19 @@ public class NativeDateTest {
 
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "\"en-US\""), "test.js", 0, null);
-                        assertEquals("December 18, 2021 2:23:00 PM PST", res);
+                        assertEquals("December 18, 2021 10:23:00 PM GMT", res);
                     }
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "\"de-DE\""), "test.js", 0, null);
-                        assertEquals("Dezember 18, 2021 2:23:00 nachm. PST", res);
+                        assertEquals("Dezember 18, 2021 10:23:00 nachm. GMT", res);
                     }
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "\"ja-JP\""), "test.js", 0, null);
-                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                        assertEquals("12月 18, 2021 10:23:00 午後 GMT", res);
                     }
                     {
                         final String res = (String)cx.evaluateString(scope, String.format(js, "['foo', 'ja-JP', 'en-US']"), "test.js", 0, null);
-                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                        assertEquals("12月 18, 2021 10:23:00 午後 GMT", res);
                     }
                     return null;
                 });

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -83,6 +83,22 @@ public class NativeDateTest {
     }
 
     @Test
+    public void ctorDateTimeTokyo() {
+        String js = "new Date('2021-12-18T22:23').toISOString()";
+
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    cx.setTimeZone(TimeZone.getTimeZone("Asia/Tokyo"));
+
+                    final Object res = cx.evaluateString(scope, js, "test.js", 0, null);
+                    assertEquals("2021-12-18T13:23:00.000Z", res);
+                    return null;
+                });
+    }
+
+    @Test
     public void ctorDate() {
         String js = "new Date('2021-12-18').toISOString()";
 
@@ -174,6 +190,22 @@ public class NativeDateTest {
 
                     final Double res = (Double) cx.evaluateString(scope, js, "test.js", 0, null);
                     assertEquals(300, res.doubleValue(), 0.0001);
+                    return null;
+                });
+    }
+
+    @Test
+    public void timezoneOffsetTokyo() {
+        String js = "new Date(0).getTimezoneOffset()";
+
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    cx.setTimeZone(TimeZone.getTimeZone("Asia/Tokyo"));
+
+                    final Double res = (Double) cx.evaluateString(scope, js, "test.js", 0, null);
+                    assertEquals(-540, res.doubleValue(), 0.0001);
                     return null;
                 });
     }

--- a/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/testsrc/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -209,4 +209,33 @@ public class NativeDateTest {
                     return null;
                 });
     }
+
+    @Test
+    public void toLocaleString() {
+        String js = "new Date('2021-12-18T22:23').toLocaleString(%s)";
+        Utils.runWithAllOptimizationLevels(
+                cx -> {
+                    final Scriptable scope = cx.initStandardObjects();
+                    cx.setLanguageVersion(Context.VERSION_ES6);
+                    cx.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"en-US\""), "test.js", 0, null);
+                        assertEquals("December 18, 2021 2:23:00 PM PST", res);
+                    }
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"de-DE\""), "test.js", 0, null);
+                        assertEquals("Dezember 18, 2021 2:23:00 nachm. PST", res);
+                    }
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "\"ja-JP\""), "test.js", 0, null);
+                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                    }
+                    {
+                        final String res = (String)cx.evaluateString(scope, String.format(js, "['foo', 'ja-JP', 'en-US']"), "test.js", 0, null);
+                        assertEquals("12月 18, 2021 2:23:00 午後 PST", res);
+                    }
+                    return null;
+                });
+    }
 }


### PR DESCRIPTION
### This PR does the following
- Improve `NativeDate` by
  - Add Japan Standard Time (JST) support
  - Change to use `DateTimeFormatter` instead of `SimpleDateFormat`
  - Fix [Date.prototype.toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString) currently not handling locales argument
  - Make the formatter use `Context.timezone` instead of system default